### PR TITLE
Add PubMed API key CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,30 @@ npx -y @smithery/cli@latest install @JackKuo666/pubmed-mcp-server --client cline
    pip install -r requirements.txt
    ```
 
+3. *(Optional)* Set your PubMed API key to increase request limits:
+   ```bash
+   export PUBMED_API_KEY=YOUR_KEY_HERE
+   ```
+
+4. *(Optional)* If your institution provides an EZproxy service for accessing
+   publisher content, set the prefix so downloaded articles use it:
+   ```bash
+   export EZPROXY_PREFIX="https://yourlibrary.edu/login?url="
+   ```
+
 ## 📊 Usage
 
 Start the MCP server:
 
 ```bash
 python pubmed_server.py
+```
+
+You can also specify your PubMed API key and EZproxy prefix directly as
+command-line options:
+
+```bash
+python pubmed_server.py --api-key YOUR_KEY --ezproxy-prefix "https://yourlibrary.edu/login?url="
 ```
 ## Usage with Claude Desktop
 

--- a/pubmed_server.py
+++ b/pubmed_server.py
@@ -1,8 +1,33 @@
 from typing import Any, List, Dict, Optional, Union
+import argparse
+import os
 import asyncio
 import logging
+
+parser = argparse.ArgumentParser(description="Run the PubMed MCP server")
+parser.add_argument(
+    "--api-key",
+    help="PubMed API key for increased request limits",
+)
+parser.add_argument(
+    "--ezproxy-prefix",
+    help="Prefix for EZproxy based full-text access",
+)
+args, unknown = parser.parse_known_args()
+
+if args.api_key:
+    os.environ["PUBMED_API_KEY"] = args.api_key
+if args.ezproxy_prefix:
+    os.environ["EZPROXY_PREFIX"] = args.ezproxy_prefix
+
 from mcp.server.fastmcp import FastMCP
-from pubmed_web_search import search_key_words, search_advanced, get_pubmed_metadata, download_full_text_pdf, deep_paper_analysis
+from pubmed_web_search import (
+    search_key_words,
+    search_advanced,
+    get_pubmed_metadata,
+    download_full_text_pdf,
+    deep_paper_analysis,
+)
 
 # Set up logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
## Summary
- support API key and EZproxy prefix via command-line flags
- document how to start the server with these options

## Testing
- `python -m py_compile pubmed_web_search.py pubmed_server.py`
- `pip install -r requirements.txt`
- `python pubmed_server.py --help`

------
https://chatgpt.com/codex/tasks/task_e_684e982c212c832bbe0ade5e4dce5d50